### PR TITLE
Better handling of disconnect due to hitting concurrent connection limit

### DIFF
--- a/lib/rcon/error/error.rb
+++ b/lib/rcon/error/error.rb
@@ -50,6 +50,14 @@ module Rcon
       end
     end
 
+    # used for communicating that the server closed the connection
+    class ServerClosedSocketError < StandardError
+      # @return [String]
+      def message
+        "the server closed the connection. Do you have too many concurrent connections open?"
+      end
+    end
+
     # used for communicating that we timed out trying to read from the socket
     class SocketReadTimeoutError < StandardError
       # @return [String]

--- a/lib/rcon/packet.rb
+++ b/lib/rcon/packet.rb
@@ -41,15 +41,15 @@ module Rcon
     def self.read_from_socket_wrapper(socket_wrapper)
       if socket_wrapper.ready_to_read?
         size = socket_wrapper.recv(INT_BYTE_SIZE).unpack(INTEGER_PACK_DIRECTIVE).first
-        if size.empty?
-          raise ServerClosedSocketError
+        if size.nil?
+          raise Error::ServerClosedSocketError
         end
         id_and_type_length = 2 * INT_BYTE_SIZE
         body_length = size - id_and_type_length - (2 * TRAILER_BYTE_SIZE) # ignore trailing nulls
 
         payload = socket_wrapper.recv(size)
-        if payload.empty?
-          raise ServerClosedSocketError
+        if payload.nil?
+          raise Error::ServerClosedSocketError
         end
         id, type_int = payload[0...id_and_type_length].unpack("#{INTEGER_PACK_DIRECTIVE}*")
         body = payload[id_and_type_length..].unpack("#{STR_PACK_DIRECTIVE}#{body_length}").first

--- a/lib/rcon/packet.rb
+++ b/lib/rcon/packet.rb
@@ -40,7 +40,7 @@ module Rcon
     # @raise [Error::SocketReadTimeoutError] if timeout occurs while waiting to read from socket
     def self.read_from_socket_wrapper(socket_wrapper)
       if socket_wrapper.ready_to_read?
-        size = socket_wrapper.recv(INT_BYTE_SIZE).unpack(INTEGER_PACK_DIRECTIVE).first
+        size = socket_wrapper.recv(INT_BYTE_SIZE)&.unpack(INTEGER_PACK_DIRECTIVE)&.first
         if size.nil?
           raise Error::ServerClosedSocketError
         end

--- a/spec/packet_spec.rb
+++ b/spec/packet_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Rcon::Packet do
       wrapper = Rcon::SocketWrapper.new(TCPSocket.open("0.0.0.0", 2000))
 
       expect { Rcon::Packet.read_from_socket_wrapper(wrapper) }.to raise_error(
-          an_instance_of(Rcon::Error::InvalidResponsePacketTypeCodeError).and having_attributes(type_code: 5)
-        )
+        an_instance_of(Rcon::Error::InvalidResponsePacketTypeCodeError).and having_attributes(type_code: 5)
+      )
 
       server.close
     end
@@ -37,6 +37,20 @@ RSpec.describe Rcon::Packet do
       expect { Rcon::Packet.read_from_socket_wrapper(wrapper) }.to raise_error(Rcon::Error::SocketReadTimeoutError)
 
       server.close
+    end
+
+    it "raises an `Rcon::Error::ServerClosedSocketError` if the socket is closed by server" do
+      thread = Thread.new do
+        server = TCPServer.new("0.0.0.0", 2001)
+        loop do
+          client = server.accept
+          client.close
+        end
+      end
+
+      wrapper = Rcon::SocketWrapper.new(TCPSocket.open("0.0.0.0", 2001))
+
+      expect { Rcon::Packet.read_from_socket_wrapper(wrapper) }.to raise_error(Rcon::Error::ServerClosedSocketError)
     end
   end
 

--- a/spec/packet_spec.rb
+++ b/spec/packet_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Rcon::Packet do
           client.close
         end
       end
+      sleep 2
 
       wrapper = Rcon::SocketWrapper.new(TCPSocket.open("0.0.0.0", 2001))
 


### PR DESCRIPTION
I was running a few RCON-based programs against one of my servers and realized I was getting an undefined method error when connecting more than 5 RCON clients concurrently.

The error was not super clear, as it stems from `size` being `nil` due to a failed `#recv`.

https://github.com/hernanat/rconrb/blob/master/lib/rcon/packet.rb#L45

If blocking `#recv` returns `nil` it means the socket is closed. I added a nil check and it throws a new error, ServerClosedSocketError.

The test I wrote works if you run the server and client parts separately, and it mirrors what you see in a tcpdump (the server accepts the auth packet from the RCON client, then sends FIN and RST), but it fails with "err conn refused" most of the time, probably due to some race condition.

I didn't want to submit a PR without a test.